### PR TITLE
safety-tool: apply `#[safety::precond::Property]` to Rust for Linux

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -502,10 +502,14 @@ $(obj)/compiler_builtins.o: private rustc_objcopy = -w -W '__*'
 $(obj)/compiler_builtins.o: $(src)/compiler_builtins.rs $(obj)/core.o FORCE
 	+$(call if_changed_rule,rustc_library)
 
+$(obj)/safety.o: private rustc_target_flags = --extern core --extern compiler_builtins
+$(obj)/safety.o: $(src)/safety.rs $(obj)/compiler_builtins.o FORCE
+	+$(call if_changed_rule,rustc_library)
+
 $(obj)/pin_init.o: private skip_gendwarfksyms = 1
 $(obj)/pin_init.o: private rustc_target_flags = --extern pin_init_internal \
     --extern macros --cfg kernel
-$(obj)/pin_init.o: $(src)/pin-init/src/lib.rs $(obj)/compiler_builtins.o \
+$(obj)/pin_init.o: $(src)/pin-init/src/lib.rs $(obj)/compiler_builtins.o $(obj)/safety.o \
     $(obj)/$(libpin_init_internal_name) $(obj)/$(libmacros_name) FORCE
 	+$(call if_changed_rule,rustc_library)
 

--- a/rust/kernel/list.rs
+++ b/rust/kernel/list.rs
@@ -22,6 +22,7 @@ pub use self::arc::{impl_list_arc_safe, AtomicTracker, ListArc, ListArcSafe, Try
 mod arc_field;
 pub use self::arc_field::{define_list_arc_field_getter, ListArcField};
 
+extern crate safety_macro as safety;
 /// A linked list.
 ///
 /// All elements in this linked list will be [`ListArc`] references to the value. Since a value can
@@ -187,6 +188,7 @@ pub unsafe trait ListItem<const ID: u64 = 0>: ListArcSafe<ID> {
     /// # Safety
     ///
     /// The provided pointer must point at a valid value. (It need not be in an `Arc`.)
+    //#[safety::Memo(UserProperty, memo = "The provided pointer must point at a valid value.")] //valid_ptr(me)
     unsafe fn view_links(me: *const Self) -> *mut ListLinks<ID>;
 
     /// View the full value given its [`ListLinks`] field.
@@ -205,6 +207,8 @@ pub unsafe trait ListItem<const ID: u64 = 0>: ListArcSafe<ID> {
     ///   `prepare_to_insert`.
     /// * Since the most recent call to `prepare_to_insert`, the `post_remove` method must not have
     ///   been called.
+    //#[safety::Memo(UserProperty, memo = "The provided value 'me' must originate from the most recent call to 'prepare_to_insert'.")] //originate_from_recent(me, prepare_to_insert)
+    //#[safety::Memo(UserProperty, memo = "The provided value 'me' must originate from a call to view_links that happened after the most recent call to 'prepare_to_insert'.")] //originate_from(me, view_links, prepare_to_insert)
     unsafe fn view_value(me: *mut ListLinks<ID>) -> *const Self;
 
     /// This is called when an item is inserted into a [`List`].
@@ -223,6 +227,7 @@ pub unsafe trait ListItem<const ID: u64 = 0>: ListArcSafe<ID> {
     ///   called after this call to `prepare_to_insert`.
     ///
     /// [`Arc`]: crate::sync::Arc
+    //#[safety::Memo(UserProperty, memo = "The provided pointer 'me' must point at a valid value in an Arc.")] //wrapper(me, Arc)
     unsafe fn prepare_to_insert(me: *const Self) -> *mut ListLinks<ID>;
 
     /// This undoes a previous call to `prepare_to_insert`.
@@ -235,6 +240,7 @@ pub unsafe trait ListItem<const ID: u64 = 0>: ListArcSafe<ID> {
     ///
     /// The provided pointer must be the pointer returned by the most recent call to
     /// `prepare_to_insert`.
+    //#[safety::Memo(originate_from_recent(me, prepare_to_insert), memo = "The provided value 'me' must originate from the most recent call to 'prepare_to_insert'.")] //originate_from_recent(me, prepare_to_insert)
     unsafe fn post_remove(me: *mut ListLinks<ID>) -> *const Self;
 }
 
@@ -281,6 +287,7 @@ impl<const ID: u64> ListLinks<ID> {
     /// # Safety
     ///
     /// `me` must be dereferenceable.
+    #[safety::Precond_Typed(me, "ListLinks<ID>")]
     #[inline]
     unsafe fn fields(me: *mut Self) -> *mut ListLinksFields {
         // SAFETY: The caller promises that the pointer is valid.
@@ -290,6 +297,7 @@ impl<const ID: u64> ListLinks<ID> {
     /// # Safety
     ///
     /// `me` must be dereferenceable.
+    #[safety::Precond_Typed(me, "ListLinksFields")]
     #[inline]
     unsafe fn from_fields(me: *mut ListLinksFields) -> *mut Self {
         me.cast()
@@ -362,6 +370,7 @@ impl<T: ?Sized + ListItem<ID>, const ID: u64> List<T, ID> {
     ///
     /// * `next` must be an element in this list or null.
     /// * if `next` is null, then the list must be empty.
+    // seems no need to abstract, it is a specific usage
     unsafe fn insert_inner(
         &mut self,
         item: ListArc<T, ID>,
@@ -510,6 +519,7 @@ impl<T: ?Sized + ListItem<ID>, const ID: u64> List<T, ID> {
     ///
     /// The `item` pointer must point at an item in this list, and we must have `(*item).next ==
     /// next` and `(*item).prev == prev`.
+    // seems no need to abstract, it is a specific usage
     unsafe fn remove_internal_inner(
         &mut self,
         item: *mut ListLinksFields,
@@ -781,7 +791,7 @@ impl<'a, T: ?Sized + ListItem<ID>, const ID: u64> Iterator for Iter<'a, T, ID> {
 ///             if to_insert.value < next.value {
 ///                 break;
 ///             }
-///             cursor.move_next();
+///             cursor.move_next();/* */
 ///         }
 ///         cursor.insert_prev(to_insert);
 ///     }

--- a/rust/kernel/list.rs
+++ b/rust/kernel/list.rs
@@ -22,7 +22,6 @@ pub use self::arc::{impl_list_arc_safe, AtomicTracker, ListArc, ListArcSafe, Try
 mod arc_field;
 pub use self::arc_field::{define_list_arc_field_getter, ListArcField};
 
-extern crate safety_macro as safety;
 /// A linked list.
 ///
 /// All elements in this linked list will be [`ListArc`] references to the value. Since a value can
@@ -287,7 +286,7 @@ impl<const ID: u64> ListLinks<ID> {
     /// # Safety
     ///
     /// `me` must be dereferenceable.
-    #[safety::Precond_Typed(me, "ListLinks<ID>")]
+    #[safety::precond::Typed(me, "ListLinks<ID>")]
     #[inline]
     unsafe fn fields(me: *mut Self) -> *mut ListLinksFields {
         // SAFETY: The caller promises that the pointer is valid.
@@ -297,7 +296,7 @@ impl<const ID: u64> ListLinks<ID> {
     /// # Safety
     ///
     /// `me` must be dereferenceable.
-    #[safety::Precond_Typed(me, "ListLinksFields")]
+    #[safety::precond::Typed(me, "ListLinksFields")]
     #[inline]
     unsafe fn from_fields(me: *mut ListLinksFields) -> *mut Self {
         me.cast()

--- a/rust/kernel/list/arc_field.rs
+++ b/rust/kernel/list/arc_field.rs
@@ -10,7 +10,7 @@
 //! [`ListArc`]: crate::list::ListArc
 
 use core::cell::UnsafeCell;
-
+extern crate safety_macro as safety;
 /// A field owned by a specific [`ListArc`].
 ///
 /// [`ListArc`]: crate::list::ListArc
@@ -44,6 +44,7 @@ impl<T, const ID: u64> ListArcField<T, ID> {
     ///
     /// The caller must have shared access to the `ListArc<ID>` containing the struct with this
     /// field for the duration of the returned reference.
+    #[safety::Memo(UserProperty, memo = "The caller must have shared access to T for the duration of the returned reference.")] 
     pub unsafe fn assert_ref(&self) -> &T {
         // SAFETY: The caller has shared access to the `ListArc`, so they also have shared access
         // to this field.
@@ -56,6 +57,7 @@ impl<T, const ID: u64> ListArcField<T, ID> {
     ///
     /// The caller must have mutable access to the `ListArc<ID>` containing the struct with this
     /// field for the duration of the returned reference.
+    #[safety::Memo(UserProperty, memo = "The caller must have mutable access to T for the duration of the returned mutable reference.")] 
     #[expect(clippy::mut_from_ref)]
     pub unsafe fn assert_mut(&self) -> &mut T {
         // SAFETY: The caller has exclusive access to the `ListArc`, so they also have exclusive

--- a/rust/kernel/list/arc_field.rs
+++ b/rust/kernel/list/arc_field.rs
@@ -10,7 +10,7 @@
 //! [`ListArc`]: crate::list::ListArc
 
 use core::cell::UnsafeCell;
-extern crate safety_macro as safety;
+
 /// A field owned by a specific [`ListArc`].
 ///
 /// [`ListArc`]: crate::list::ListArc
@@ -44,7 +44,10 @@ impl<T, const ID: u64> ListArcField<T, ID> {
     ///
     /// The caller must have shared access to the `ListArc<ID>` containing the struct with this
     /// field for the duration of the returned reference.
-    #[safety::Memo(UserProperty, memo = "The caller must have shared access to T for the duration of the returned reference.")] 
+    #[safety::Memo(
+        UserProperty,
+        memo = "The caller must have shared access to T for the duration of the returned reference."
+    )]
     pub unsafe fn assert_ref(&self) -> &T {
         // SAFETY: The caller has shared access to the `ListArc`, so they also have shared access
         // to this field.
@@ -57,7 +60,10 @@ impl<T, const ID: u64> ListArcField<T, ID> {
     ///
     /// The caller must have mutable access to the `ListArc<ID>` containing the struct with this
     /// field for the duration of the returned reference.
-    #[safety::Memo(UserProperty, memo = "The caller must have mutable access to T for the duration of the returned mutable reference.")] 
+    #[safety::Memo(
+        UserProperty,
+        memo = "The caller must have mutable access to T for the duration of the returned mutable reference."
+    )]
     #[expect(clippy::mut_from_ref)]
     pub unsafe fn assert_mut(&self) -> &mut T {
         // SAFETY: The caller has exclusive access to the `ListArc`, so they also have exclusive

--- a/rust/kernel/list/impl_list_item_mod.rs
+++ b/rust/kernel/list/impl_list_item_mod.rs
@@ -5,7 +5,7 @@
 //! Helpers for implementing list traits safely.
 
 use crate::list::ListLinks;
-extern crate safety_macro as safety;
+
 /// Declares that this type has a `ListLinks<ID>` field at a fixed offset.
 ///
 /// This trait is only used to help implement `ListItem` safely. If `ListItem` is implemented

--- a/rust/kernel/list/impl_list_item_mod.rs
+++ b/rust/kernel/list/impl_list_item_mod.rs
@@ -5,7 +5,7 @@
 //! Helpers for implementing list traits safely.
 
 use crate::list::ListLinks;
-
+extern crate safety_macro as safety;
 /// Declares that this type has a `ListLinks<ID>` field at a fixed offset.
 ///
 /// This trait is only used to help implement `ListItem` safely. If `ListItem` is implemented
@@ -30,6 +30,7 @@ pub unsafe trait HasListLinks<const ID: u64 = 0> {
     /// [`ListLinks<T, ID>`]: ListLinks
     // We don't really need this method, but it's necessary for the implementation of
     // `impl_has_list_links!` to be correct.
+    //#[safety::Precond_Typed(ptr, "Self")]
     #[inline]
     unsafe fn raw_get_list_links(ptr: *mut Self) -> *mut ListLinks<ID> {
         // SAFETY: The caller promises that the pointer is valid. The implementer promises that the

--- a/rust/pin-init/src/lib.rs
+++ b/rust/pin-init/src/lib.rs
@@ -289,7 +289,6 @@ use core::{
     pin::Pin,
     ptr::{self, NonNull},
 };
-extern crate safety_macro as safety;
 
 #[doc(hidden)]
 pub mod __internal;
@@ -1062,8 +1061,8 @@ pub unsafe trait PinInit<T: ?Sized, E = Infallible>: Sized {
     /// - the caller does not touch `slot` when `Err` is returned, they are only permitted to
     ///   deallocate.
     /// - `slot` will not move until it is dropped, i.e. it will be pinned.
-    // #[safety::Precond_Allocated(slot, T, 1, _)]
-    // #[safety::Hazard_Pinned(slot, _)]
+    // #[safety::precond::Allocated(slot, T, 1, _)]
+    // #[safety::hazard::Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E>;
 
     /// First initializes the value using `self` then calls the function `f` with the initialized
@@ -1104,8 +1103,8 @@ where
     I: PinInit<T, E>,
     F: FnOnce(Pin<&mut T>) -> Result<(), E>,
 {
-    #[safety::Precond_Allocated(slot, T, 1, _)]
-    #[safety::Hazard_Pinned(slot, _)]
+    #[safety::precond::Allocated(slot, T, 1, _)]
+    #[safety::hazard::Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: All requirements fulfilled since this function is `__pinned_init`.
         unsafe { self.0.__pinned_init(slot)? };
@@ -1164,7 +1163,7 @@ pub unsafe trait Init<T: ?Sized, E = Infallible>: PinInit<T, E> {
     /// - `slot` is a valid pointer to uninitialized memory.
     /// - the caller does not touch `slot` when `Err` is returned, they are only permitted to
     ///   deallocate.
-    // #[safety::Precond_Allocated(slot, T, 1, _)]
+    // #[safety::precond::Allocated(slot, T, 1, _)]
     unsafe fn __init(self, slot: *mut T) -> Result<(), E>;
 
     /// First initializes the value using `self` then calls the function `f` with the initialized
@@ -1214,7 +1213,7 @@ where
     I: Init<T, E>,
     F: FnOnce(&mut T) -> Result<(), E>,
 {
-    #[safety::Precond_Allocated(slot, T, 1, _)]
+    #[safety::precond::Allocated(slot, T, 1, _)]
     unsafe fn __init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: All requirements fulfilled since this function is `__init`.
         unsafe { self.0.__pinned_init(slot)? };
@@ -1231,8 +1230,8 @@ where
     I: Init<T, E>,
     F: FnOnce(&mut T) -> Result<(), E>,
 {
-    #[safety::Precond_Allocated(slot, T, 1, _)]
-    #[safety::Hazard_Pinned(slot, _)]
+    #[safety::precond::Allocated(slot, T, 1, _)]
+    #[safety::hazard::Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: `__init` has less strict requirements compared to `__pinned_init`.
         unsafe { self.__init(slot) }
@@ -1401,7 +1400,7 @@ where
 
 // SAFETY: Every type can be initialized by-value.
 unsafe impl<T, E> Init<T, E> for T {
-    #[safety::Precond_Allocated(slot, T, 1, _)]
+    #[safety::precond::Allocated(slot, T, 1, _)]
     unsafe fn __init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: TODO.
         unsafe { slot.write(self) };
@@ -1411,8 +1410,8 @@ unsafe impl<T, E> Init<T, E> for T {
 
 // SAFETY: Every type can be initialized by-value. `__pinned_init` calls `__init`.
 unsafe impl<T, E> PinInit<T, E> for T {
-    #[safety::Precond_Allocated(slot, T, 1, _)]
-    #[safety::Hazard_Pinned(slot, _)]
+    #[safety::precond::Allocated(slot, T, 1, _)]
+    #[safety::hazard::Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: TODO.
         unsafe { self.__init(slot) }

--- a/rust/pin-init/src/lib.rs
+++ b/rust/pin-init/src/lib.rs
@@ -289,7 +289,7 @@ use core::{
     pin::Pin,
     ptr::{self, NonNull},
 };
-use safety_tool_lib::safety;
+extern crate safety_macro as safety;
 
 #[doc(hidden)]
 pub mod __internal;
@@ -1062,8 +1062,8 @@ pub unsafe trait PinInit<T: ?Sized, E = Infallible>: Sized {
     /// - the caller does not touch `slot` when `Err` is returned, they are only permitted to
     ///   deallocate.
     /// - `slot` will not move until it is dropped, i.e. it will be pinned.
-    #[safety::precond::Allocated(slot, T, 1, _)]
-    #[safety::hazard::Pinned(slot, _)]
+    // #[safety::Precond_Allocated(slot, T, 1, _)]
+    // #[safety::Hazard_Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E>;
 
     /// First initializes the value using `self` then calls the function `f` with the initialized
@@ -1104,8 +1104,8 @@ where
     I: PinInit<T, E>,
     F: FnOnce(Pin<&mut T>) -> Result<(), E>,
 {
-    #[safety::precond::Allocated(slot, T, 1, _)]
-    #[safety::hazard::Pinned(slot, _)]
+    #[safety::Precond_Allocated(slot, T, 1, _)]
+    #[safety::Hazard_Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: All requirements fulfilled since this function is `__pinned_init`.
         unsafe { self.0.__pinned_init(slot)? };
@@ -1164,7 +1164,7 @@ pub unsafe trait Init<T: ?Sized, E = Infallible>: PinInit<T, E> {
     /// - `slot` is a valid pointer to uninitialized memory.
     /// - the caller does not touch `slot` when `Err` is returned, they are only permitted to
     ///   deallocate.
-    #[safety::precond::Allocated(slot, T, 1, _)]
+    // #[safety::Precond_Allocated(slot, T, 1, _)]
     unsafe fn __init(self, slot: *mut T) -> Result<(), E>;
 
     /// First initializes the value using `self` then calls the function `f` with the initialized
@@ -1214,7 +1214,7 @@ where
     I: Init<T, E>,
     F: FnOnce(&mut T) -> Result<(), E>,
 {
-    #[safety::precond::Allocated(slot, T, 1, _)]
+    #[safety::Precond_Allocated(slot, T, 1, _)]
     unsafe fn __init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: All requirements fulfilled since this function is `__init`.
         unsafe { self.0.__pinned_init(slot)? };
@@ -1231,8 +1231,8 @@ where
     I: Init<T, E>,
     F: FnOnce(&mut T) -> Result<(), E>,
 {
-    #[safety::precond::Allocated(slot, T, 1, _)]
-    #[safety::hazard::Pinned(slot, _)]
+    #[safety::Precond_Allocated(slot, T, 1, _)]
+    #[safety::Hazard_Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: `__init` has less strict requirements compared to `__pinned_init`.
         unsafe { self.__init(slot) }
@@ -1401,7 +1401,7 @@ where
 
 // SAFETY: Every type can be initialized by-value.
 unsafe impl<T, E> Init<T, E> for T {
-    #[safety::precond::Allocated(slot, T, 1, _)]
+    #[safety::Precond_Allocated(slot, T, 1, _)]
     unsafe fn __init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: TODO.
         unsafe { slot.write(self) };
@@ -1411,8 +1411,8 @@ unsafe impl<T, E> Init<T, E> for T {
 
 // SAFETY: Every type can be initialized by-value. `__pinned_init` calls `__init`.
 unsafe impl<T, E> PinInit<T, E> for T {
-    #[safety::precond::Allocated(slot, T, 1, _)]
-    #[safety::hazard::Pinned(slot, _)]
+    #[safety::Precond_Allocated(slot, T, 1, _)]
+    #[safety::Hazard_Pinned(slot, _)]
     unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
         // SAFETY: TODO.
         unsafe { self.__init(slot) }

--- a/rust/safety.rs
+++ b/rust/safety.rs
@@ -1,0 +1,52 @@
+#![no_std]
+pub use safety_macro::Memo;
+pub use safety_macro::discharges;
+
+use safety_macro::pub_use;
+pub mod precond {
+    super::pub_use! {
+        Precond_Align,
+        Precond_Size,
+        Precond_NoPadding,
+        Precond_NonNull,
+        Precond_Allocated,
+        Precond_InBound,
+        Precond_NonOverlap,
+        Precond_ValidNum,
+        Precond_ValidString,
+        Precond_ValidCStr,
+        Precond_Init,
+        Precond_Unwrap,
+        Precond_Typed,
+        Precond_Owning,
+        Precond_Alias,
+        Precond_Alive,
+        Precond_Pinned,
+        Precond_NonVolatile,
+        Precond_Opened,
+        Precond_Trait,
+        Precond_Unreachable,
+        Precond_ValidPtr,
+        Precond_Deref,
+        Precond_Ptr2Ref,
+        Precond_Layout
+    }
+}
+
+pub mod hazard {
+    super::pub_use! {
+        Hazard_ValidString,
+        Hazard_Init,
+        Hazard_Alias,
+        Hazard_Pinned,
+        Hazard_Ptr2Ref,
+    }
+}
+
+pub mod option {
+    super::pub_use! {
+        Option_Size,
+        Option_Init,
+        Option_Trait,
+    }
+}

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -323,7 +323,7 @@ rust_allowed_features := asm_const,asm_goto,arbitrary_self_types,lint_reasons,ra
 rust_common_cmd = \
 	OBJTREE=$(abspath $(objtree)) \
 	RUST_MODFILE=$(modfile) $(RUSTC_OR_CLIPPY) $(rust_flags) \
-	-Zallow-features=$(rust_allowed_features) \
+	-Zallow-features=$(rust_allowed_features),register_tool \
 	-Zcrate-attr=no_std \
 	-Zcrate-attr='feature($(rust_allowed_features))' \
 	-Zunstable-options --extern pin_init --extern kernel \


### PR DESCRIPTION
This PR adds basic support of safety attributes to rfl:

```rust
#[safety::Memo(Prop, memo = "reason")]
unsafe fn foo() { ... }

#[safety::precond::Prop]
unsafe fn bar() { ... }
```

NOTE: to obtain a user-friendly path-based attribute syntax, we copy safety.rs into `rust/` folder, and define a `safety.o` target in Makefile.

* cc https://github.com/Artisan-Lab/tag-std/pull/24

